### PR TITLE
Pools could be mixed up caused by identical variable name that was previously used as reference

### DIFF
--- a/classes/class.ilObjMatchMemoPool.php
+++ b/classes/class.ilObjMatchMemoPool.php
@@ -273,9 +273,9 @@ class ilObjMatchMemoPool extends ilObjectPlugin
 			}
 
 			$valid_pools = array();
-			foreach($pools_by_percent as $pools)
+			foreach($pools_by_percent as $validPools)
 			{
-				foreach($pools as $pool)
+				foreach($validPools as $pool)
 				{
 					$valid_pools[] = $pool;
 				}
@@ -286,7 +286,11 @@ class ilObjMatchMemoPool extends ilObjectPlugin
 			foreach($valid_pools as $data)
 			{
 				$pairs  = array();
-				$result = $ilDB->queryF("SELECT rep_robj_xmpl_pair.pair_id FROM rep_robj_xmpl_pair, rep_robj_xmry_pair WHERE rep_robj_xmry_pair.pair_fi = rep_robj_xmpl_pair.pair_id AND rep_robj_xmpl_pair.obj_fi = %s AND rep_robj_xmry_pair.obj_fi = %s", 
+				$result = $ilDB->queryF("SELECT rep_robj_xmpl_pair.pair_id
+					FROM rep_robj_xmpl_pair, rep_robj_xmry_pair
+					WHERE rep_robj_xmry_pair.pair_fi = rep_robj_xmpl_pair.pair_id
+					AND rep_robj_xmpl_pair.obj_fi = %s
+					AND rep_robj_xmry_pair.obj_fi = %s",
 					array('integer', 'integer'),
 					array($data['obj_id'], $game_id)
 				);


### PR DESCRIPTION
This fixes the behavior that sometimes to few cards were selected.
Example:
```
Set A: 50%
Set B: 25%
Set C: 25%
```
Some of the lower percentages could randomly slip into `$valid_pools` because the same variable name was previously used and results into this odd behavior.

This PR just renamed the variable(and formatted the SQL-Statement because I couldn't read it on my little screen)